### PR TITLE
Redirect `RelayExpr` to `Expr`

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -360,5 +360,15 @@ def process_docstring(app, what, name, obj, options, lines):
         distinguish_class_name(name, lines)
 
 
+def process_signature(app, what, name, obj, options, signature, return_annotation):
+    """Sphinx callback to process signature"""
+    if signature is not None:
+        signature = re.sub(r"\bRelayExpr\b", "Expr", signature)
+    if return_annotation is not None:
+        return_annotation = re.sub(r"\bRelayExpr\b", "Expr", return_annotation)
+    return signature, return_annotation
+
+
 def setup(app):
     app.connect("autodoc-process-docstring", process_docstring)
+    app.connect("autodoc-process-signature", process_signature)

--- a/docs/reference/api/relax/frontend.rst
+++ b/docs/reference/api/relax/frontend.rst
@@ -27,7 +27,7 @@ tvm.relax.frontend.nn
    :members:
    :imported-members:
    :exclude-members: BlockBuilder
-   :noindex: Module
+   :noindex:
 
 tvm.relax.frontend.onnx
 ***********************

--- a/docs/reference/api/relax/relax.rst
+++ b/docs/reference/api/relax/relax.rst
@@ -18,8 +18,6 @@
 tvm.relax
 ---------
 .. automodule:: tvm.relax
-   :members:
-   :imported-members:
-   :exclude-members: BlockBuilder, Span, GlobalVar, SourceName, TupleType, Type, FuncType
-   :noindex: Tuple
-
+    :members:
+    :imported-members:
+    :exclude-members: BlockBuilder, Span, GlobalVar, SourceName, TupleType, Type, FuncType

--- a/docs/reference/api/topi.rst
+++ b/docs/reference/api/topi.rst
@@ -23,8 +23,7 @@ tvm.topi
 .. automodule:: tvm.topi
    :members:
    :imported-members:
-   :exclude-members: PrimExpr
-   :noindex: Cast
+   :exclude-members: PrimExpr, Cast
 
 tvm.topi.nn
 ~~~~~~~~~~~


### PR DESCRIPTION
As `relax.Expr` is just an alias of `tvm.relay.Expr`, but it is not expected to be shown in the function annotation. This PR redirects `RelayExpr` to `Expr` via customizing the hook.

Besides, `noindex` does not work for a single class, but skip the whole module. This PR also fixes this issue.